### PR TITLE
Implement host orchestration and MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# MCP Example Platform
+
+This repository contains a small platform that demonstrates how a FastAPI host
+application can orchestrate multiple Model Context Protocol (MCP) compatible
+servers. Two tool servers are provided:
+
+* **Math Toolkit** – exposes basic arithmetic operations over a streamable HTTP
+  interface implemented with a lightweight `fastmcp` helper.
+* **Weather Toolkit** – serves a simple weather lookup service over streaming
+  HTTP using an equally small `mcp` helper.
+
+The host application exposes a `/conversation` endpoint that routes incoming
+questions to the appropriate MCP tool, produces a human friendly reply and
+includes a record of the streaming events that were emitted during the tool
+invocation.
+
+## Features
+
+* Stream-aware HTTP client base class that converts tool responses into
+  structured `ToolResponse` objects.
+* Math client with add, subtract and multiply helpers that communicate with the
+  FastMCP-based math server.
+* Weather client capable of retrieving temperatures in Celsius or Fahrenheit
+  from the MCP server.
+* FastAPI host service with request routing, response formatting and graceful
+  fallbacks when a question is not understood.
+* Comprehensive test suite that exercises the servers, clients and host
+  end-to-end via ASGI transports.
+
+## Change History
+
+* **v0.1.0** – Initial end-to-end implementation of the host service, math and
+  weather MCP servers, typed client SDK, automated tests and developer tooling.
+
+## Running the services locally
+
+The project uses standard ASGI applications, so the services can be launched
+with Uvicorn. A typical development workflow looks like this:
+
+```bash
+# Optionally create a virtual environment first
+python -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies for the host and tests
+pip install fastapi httpx pydantic uvicorn pytest pytest-asyncio ruff
+
+# Run the math MCP server
+uvicorn mcp_server.server_a.server:app --reload --port 8001
+
+# Run the weather MCP server in a separate terminal
+uvicorn mcp_server.server_b.server:app --reload --port 8002
+
+# Launch the host FastAPI app
+uvicorn host.app.app:app --reload --port 8000
+```
+
+Once all three services are running you can interact with the host endpoint:
+
+```bash
+curl -X POST http://localhost:8000/conversation \
+     -H "Content-Type: application/json" \
+     -d '{"question": "What is 12 + 7?", "interaction_id": "demo-1"}'
+```
+
+The response will include the generated reply plus all streamed events from the
+invoked tool.
+
+### Running the automated checks
+
+```bash
+ruff check .
+pytest
+```
+
+## Future improvements
+
+* Expand the math server with division, power operations and better numeric
+  parsing in the host router.
+* Swap the in-repository `fastmcp`/`mcp` shims with the official packages once
+  they are available in the execution environment.
+* Persist conversation history and expose past tool invocations from the host
+  API.
+* Provide Docker Compose definitions for running all services together with a
+  single command.
+

--- a/fastmcp/__init__.py
+++ b/fastmcp/__init__.py
@@ -1,0 +1,103 @@
+"""A tiny FastMCP-inspired framework used for tests.
+
+This implementation is intentionally lightweight; it mimics the API surface
+used by the example servers so the code remains self-contained for unit tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+
+@dataclass
+class StreamingEvent:
+    """Represents a structured event emitted during a tool invocation."""
+
+    status: str
+    payload: dict[str, Any]
+
+
+class FastMCP:
+    """Minimal server for exposing tools over HTTP with streaming responses."""
+
+    def __init__(self, name: str, *, metadata: dict[str, Any] | None = None) -> None:
+        self.name = name
+        self.metadata = metadata or {}
+        self._tools: dict[str, Callable[..., Awaitable[Any]]] = {}
+        self._app: FastAPI | None = None
+
+    def tool(self, func: Callable[..., Any] | None = None, *, name: str | None = None) -> Callable:
+        """Register a tool function that can be invoked via HTTP."""
+
+        def decorator(inner: Callable[..., Any]) -> Callable[..., Any]:
+            tool_name = name or inner.__name__
+
+            async def async_wrapper(**kwargs: Any) -> Any:
+                result = inner(**kwargs)
+                if asyncio.iscoroutine(result):
+                    return await result
+                return result
+
+            self._tools[tool_name] = async_wrapper
+            return inner
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    @property
+    def app(self) -> FastAPI:
+        """Return the ASGI application for the server."""
+
+        if self._app is None:
+            self._app = self._create_app()
+        return self._app
+
+    def _create_app(self) -> FastAPI:
+        app = FastAPI(title=self.name)
+
+        @app.get("/.well-known/mcp.json")
+        async def metadata() -> dict[str, Any]:
+            return {"name": self.name, "metadata": self.metadata, "tools": list(self._tools)}
+
+        @app.post("/tools/{tool_name}")
+        async def invoke(tool_name: str, request: Request) -> StreamingResponse:
+            if tool_name not in self._tools:
+                raise HTTPException(status_code=404, detail=f"Unknown tool '{tool_name}'")
+
+            payload = await request.json()
+            tool = self._tools[tool_name]
+
+            async def event_stream() -> AsyncIterator[bytes]:
+                started = {"status": "started", "tool": tool_name}
+                yield json.dumps(started).encode("utf-8") + b"\n"
+                try:
+                    result = await tool(**payload)
+                except Exception as exc:  # pragma: no cover - surfaced to caller
+                    error = {"status": "error", "error": str(exc)}
+                    yield json.dumps(error).encode("utf-8") + b"\n"
+                    raise
+
+                completed = {"status": "completed", "result": result}
+                yield json.dumps(completed).encode("utf-8") + b"\n"
+
+            return StreamingResponse(event_stream(), media_type="application/json")
+
+        return app
+
+    @asynccontextmanager
+    async def lifespan(self) -> AsyncIterator[FastAPI]:
+        yield self.app
+
+    def run(self, **uvicorn_options: Any) -> None:  # pragma: no cover - helper for manual runs
+        import uvicorn
+
+        uvicorn.run(self.app, **uvicorn_options)
+

--- a/host/__init__.py
+++ b/host/__init__.py
@@ -1,0 +1,2 @@
+"""Host application package."""
+

--- a/host/app/app.py
+++ b/host/app/app.py
@@ -1,13 +1,165 @@
-from fastapi import FastAPI
-from app.schema import RequestConversation
+"""FastAPI application that routes questions to MCP tool clients."""
+from __future__ import annotations
+
+import os
+import re
+
+from fastapi import Depends, FastAPI, HTTPException
+
+from host.mcp_client.client import ToolInvocationError, ToolResponse
+from host.mcp_client.client_a import MathMCPClient
+from host.mcp_client.client_b import WeatherMCPClient
+from host.schema.schema import (
+    ConversationResponse,
+    RequestConversation,
+    ToolCallSummary,
+)
+
+_OPERATION_SYMBOLS = {"add": "+", "subtract": "-", "multiply": "×"}
 
 
-app = FastAPI()
+class ClientRegistry:
+    """Container holding the concrete MCP clients used by the API."""
 
-@app.get("/")
-async def hello_world():
-    return {"Hello": "World"}
+    def __init__(self, math_client: MathMCPClient, weather_client: WeatherMCPClient) -> None:
+        self.math = math_client
+        self.weather = weather_client
 
-@app.post("/conversation")
-async def conversation(request: RequestConversation):
-    return {"message": "This is the conversation endpoint", "data": request}
+
+def parse_math_question(question: str) -> tuple[str, float, float] | None:
+    lowered = question.lower()
+    numbers = re.findall(r"-?\d+(?:\.\d+)?", question)
+    if len(numbers) < 2:
+        return None
+
+    if any(keyword in lowered for keyword in {"multiply", "times", "product", "*"}):
+        operation = "multiply"
+    elif any(keyword in lowered for keyword in {"subtract", "minus", "difference", "-"}):
+        operation = "subtract"
+    else:
+        operation = "add"
+
+    a, b = map(float, numbers[:2])
+    return operation, a, b
+
+
+def parse_weather_question(question: str) -> tuple[str, str] | None:
+    lowered = question.lower()
+    unit = "fahrenheit" if "fahrenheit" in lowered else "celsius"
+    location_match = re.search(r"in ([a-z\s]+?)(?:\?|\.|!|$)", lowered)
+    if not location_match:
+        return None
+    location = location_match.group(1).strip()
+    if " in " in location:
+        location = location.split(" in ", 1)[0].strip()
+    location = location.rstrip(".?!")
+    if not location:
+        return None
+    return location, unit
+
+
+def format_math_reply(response: ToolResponse) -> str:
+    result = response.result
+    if isinstance(result, dict):
+        total = result.get("total")
+        operands = result.get("operands")
+        operation = result.get("operation", response.tool_name)
+        if total is not None and operands:
+            symbol = _OPERATION_SYMBOLS.get(operation, operation)
+            return (
+                f"The result of {operands[0]} {symbol} {operands[1]} is {total}."
+            )
+    return f"The tool returned: {result}"
+
+
+def format_weather_reply(response: ToolResponse) -> str:
+    result = response.result
+    if isinstance(result, dict):
+        location = result.get("location", "the requested location")
+        condition = result.get("condition")
+        temperature = result.get("temperature")
+        unit = result.get("unit", "celsius")
+        if condition is not None and temperature is not None:
+            unit_suffix = "°F" if unit == "fahrenheit" else "°C"
+            return (
+                f"The weather in {location} is {condition} "
+                f"with a temperature of {temperature}{unit_suffix}."
+            )
+    return f"Weather tool response: {result}"
+
+
+def create_app(
+    *,
+    math_client: MathMCPClient | None = None,
+    weather_client: WeatherMCPClient | None = None,
+) -> FastAPI:
+    math_client = math_client or MathMCPClient(os.getenv("MATH_MCP_URL", "http://localhost:8001"))
+    weather_client = weather_client or WeatherMCPClient(
+        os.getenv("WEATHER_MCP_URL", "http://localhost:8002")
+    )
+    registry = ClientRegistry(math_client=math_client, weather_client=weather_client)
+
+    app = FastAPI(title="Conversation Host")
+
+    @app.get("/")
+    async def root() -> dict[str, str]:
+        return {"service": "conversation-host", "status": "ok"}
+
+    def get_registry() -> ClientRegistry:
+        return registry
+
+    @app.post("/conversation", response_model=ConversationResponse)
+    async def conversation(
+        request: RequestConversation,
+        clients: ClientRegistry = Depends(get_registry),
+    ) -> ConversationResponse:
+        math_question = parse_math_question(request.question)
+        if math_question:
+            operation, a, b = math_question
+            try:
+                tool_response = await clients.math.calculate(operation, a, b)
+            except (ToolInvocationError, ValueError) as exc:
+                raise HTTPException(status_code=502, detail=str(exc)) from exc
+            summary = ToolCallSummary(
+                name=f"math.{operation}",
+                result=tool_response.result,
+                events=tool_response.events,
+            )
+            return ConversationResponse(
+                interaction_id=request.interaction_id,
+                question=request.question,
+                reply=format_math_reply(tool_response),
+                tool=summary,
+            )
+
+        weather_question = parse_weather_question(request.question)
+        if weather_question:
+            location, unit = weather_question
+            try:
+                tool_response = await clients.weather.current_weather(location, unit)
+            except ToolInvocationError as exc:
+                raise HTTPException(status_code=502, detail=str(exc)) from exc
+            summary = ToolCallSummary(
+                name="weather.current_weather",
+                result=tool_response.result,
+                events=tool_response.events,
+            )
+            return ConversationResponse(
+                interaction_id=request.interaction_id,
+                question=request.question,
+                reply=format_weather_reply(tool_response),
+                tool=summary,
+            )
+
+        return ConversationResponse(
+            interaction_id=request.interaction_id,
+            question=request.question,
+            reply="I'm not sure how to help with that yet. Try asking about math or the weather.",
+            tool=None,
+        )
+
+    return app
+
+
+app = create_app()
+

--- a/host/mcp_client/__init__.py
+++ b/host/mcp_client/__init__.py
@@ -1,0 +1,2 @@
+"""Client implementations for communicating with MCP servers."""
+

--- a/host/mcp_client/client.py
+++ b/host/mcp_client/client.py
@@ -1,1 +1,90 @@
+"""Shared client utilities for invoking MCP tools over HTTP."""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class ToolInvocationError(RuntimeError):
+    """Raised when a tool invocation fails or returns malformed data."""
+
+
+@dataclass(slots=True)
+class ToolResponse:
+    """Represents the outcome of a tool invocation."""
+
+    tool_name: str
+    result: Any
+    events: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"tool": self.tool_name, "result": self.result, "events": self.events}
+
+
 class BaseClient:
+    """Base class handling HTTP streaming and error translation."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/") or "/"
+        self._provided_client = http_client
+        self.timeout = timeout
+
+    @asynccontextmanager
+    async def _client(self) -> httpx.AsyncClient:
+        if self._provided_client is not None:
+            yield self._provided_client
+            return
+
+        async with httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout) as client:
+            yield client
+
+    async def invoke_tool(self, tool_name: str, payload: Mapping[str, Any]) -> ToolResponse:
+        async with self._client() as client:
+            try:
+                async with client.stream(
+                    "POST",
+                    f"/tools/{tool_name}",
+                    json=dict(payload),
+                    timeout=self.timeout,
+                ) as response:
+                    response.raise_for_status()
+                    events: list[dict[str, Any]] = []
+                    async for line in response.aiter_lines():
+                        if not line:
+                            continue
+                        try:
+                            event = json.loads(line)
+                        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                            raise ToolInvocationError(
+                                f"Failed to decode event from tool '{tool_name}': {line}"
+                            ) from exc
+                        events.append(event)
+            except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive
+                detail = exc.response.text
+                raise ToolInvocationError(
+                    f"Tool '{tool_name}' returned status {exc.response.status_code}: {detail}"
+                ) from exc
+            except httpx.HTTPError as exc:  # pragma: no cover - defensive
+                message = f"HTTP error talking to tool '{tool_name}': {exc}"
+                raise ToolInvocationError(message) from exc
+
+        if not events:
+            raise ToolInvocationError(f"Tool '{tool_name}' produced no events")
+
+        final = events[-1]
+        if "result" not in final:
+            raise ToolInvocationError(f"Tool '{tool_name}' did not provide a result event")
+
+        return ToolResponse(tool_name=tool_name, result=final["result"], events=events)
+

--- a/host/mcp_client/client_a.py
+++ b/host/mcp_client/client_a.py
@@ -1,0 +1,28 @@
+"""Client for interacting with the math MCP server."""
+from __future__ import annotations
+
+from typing import Any
+
+from .client import BaseClient, ToolResponse
+
+
+class MathMCPClient(BaseClient):
+    async def add(self, a: float, b: float) -> ToolResponse:
+        return await self.invoke_tool("add", {"a": a, "b": b})
+
+    async def subtract(self, a: float, b: float) -> ToolResponse:
+        return await self.invoke_tool("subtract", {"a": a, "b": b})
+
+    async def multiply(self, a: float, b: float) -> ToolResponse:
+        return await self.invoke_tool("multiply", {"a": a, "b": b})
+
+    async def calculate(self, operation: str, a: float, b: float) -> ToolResponse:
+        operations: dict[str, Any] = {
+            "add": self.add,
+            "subtract": self.subtract,
+            "multiply": self.multiply,
+        }
+        if operation not in operations:
+            raise ValueError(f"Unsupported math operation '{operation}'")
+        return await operations[operation](a, b)
+

--- a/host/mcp_client/client_b.py
+++ b/host/mcp_client/client_b.py
@@ -1,0 +1,12 @@
+"""Client for interacting with the weather MCP server."""
+from __future__ import annotations
+
+from .client import BaseClient, ToolResponse
+
+
+class WeatherMCPClient(BaseClient):
+    async def current_weather(self, location: str, unit: str = "celsius") -> ToolResponse:
+        return await self.invoke_tool(
+            "current_weather", {"location": location, "unit": unit}
+        )
+

--- a/host/schema/__init__.py
+++ b/host/schema/__init__.py
@@ -1,0 +1,2 @@
+"""Schema definitions for the host FastAPI app."""
+

--- a/host/schema/schema.py
+++ b/host/schema/schema.py
@@ -1,5 +1,25 @@
-from pydantic import BaseModel
+"""Pydantic schemas shared by the FastAPI application."""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
 
 class RequestConversation(BaseModel):
-    question: str
+    question: str = Field(..., min_length=1)
+    interaction_id: str = Field(..., min_length=1)
+
+
+class ToolCallSummary(BaseModel):
+    name: str
+    result: Any
+    events: list[dict[str, Any]]
+
+
+class ConversationResponse(BaseModel):
     interaction_id: str
+    question: str
+    reply: str
+    tool: ToolCallSummary | None = None
+

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Simplified utilities inspired by the MCP reference implementation."""
+from .server import MCPServer
+
+__all__ = ["MCPServer"]
+

--- a/mcp/server/__init__.py
+++ b/mcp/server/__init__.py
@@ -1,0 +1,5 @@
+"""Server primitives for the local MCP example."""
+from .http import MCPServer
+
+__all__ = ["MCPServer"]
+

--- a/mcp/server/http.py
+++ b/mcp/server/http.py
@@ -1,0 +1,85 @@
+"""A tiny HTTP server for MCP style tools.
+
+The implementation mirrors the FastMCP helper but includes richer progress
+updates suitable for long running tasks.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+
+@dataclass
+class MCPEvent:
+    status: str
+    payload: dict[str, Any]
+
+
+class MCPServer:
+    """Expose decorated callables as streaming HTTP endpoints."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._tools: dict[str, Callable[..., Awaitable[Any]]] = {}
+        self._app: FastAPI | None = None
+
+    def tool(self, name: str | None = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            tool_name = name or func.__name__
+
+            async def wrapper(**kwargs: Any) -> Any:
+                result = func(**kwargs)
+                if asyncio.iscoroutine(result):
+                    return await result
+                return result
+
+            self._tools[tool_name] = wrapper
+            return func
+
+        return decorator
+
+    @property
+    def app(self) -> FastAPI:
+        if self._app is None:
+            self._app = self._create_app()
+        return self._app
+
+    def _create_app(self) -> FastAPI:
+        app = FastAPI(title=self.name)
+
+        @app.get("/.well-known/mcp.json")
+        async def metadata() -> dict[str, Any]:
+            return {"name": self.name, "tools": list(self._tools)}
+
+        @app.post("/tools/{tool_name}")
+        async def invoke(tool_name: str, request: Request) -> StreamingResponse:
+            if tool_name not in self._tools:
+                raise HTTPException(status_code=404, detail=f"Unknown tool '{tool_name}'")
+
+            payload = await request.json()
+            tool = self._tools[tool_name]
+
+            async def event_stream() -> AsyncIterator[bytes]:
+                yield json.dumps({"status": "started", "tool": tool_name}).encode() + b"\n"
+                await asyncio.sleep(0)
+                yield json.dumps({"status": "progress", "message": "processing"}).encode() + b"\n"
+                result = await tool(**payload)
+                yield (
+                    json.dumps({"status": "completed", "result": result}).encode() + b"\n"
+                )
+
+            return StreamingResponse(event_stream(), media_type="application/json")
+
+        return app
+
+    def run(self, **uvicorn_options: Any) -> None:  # pragma: no cover - manual helper
+        import uvicorn
+
+        uvicorn.run(self.app, **uvicorn_options)
+

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,2 @@
+"""Example MCP server implementations."""
+

--- a/mcp_server/server_a/__init__.py
+++ b/mcp_server/server_a/__init__.py
@@ -1,0 +1,2 @@
+"""Math MCP server package."""
+

--- a/mcp_server/server_a/server.py
+++ b/mcp_server/server_a/server.py
@@ -1,11 +1,35 @@
+"""Math oriented MCP server implemented with the FastMCP helper."""
+from __future__ import annotations
+
 from fastmcp import FastMCP
 
-mcp = FastMCP("Demo 🚀")
+mcp = FastMCP(
+    "Math Toolkit",
+    metadata={"description": "Basic arithmetic operations exposed over MCP."},
+)
 
-@mcp.tool
-def add(a: int, b: int) -> int:
-    """Add two numbers"""
-    return a + b
 
-if __name__ == "__main__":
-    mcp.run()
+@mcp.tool(name="add")
+def add(a: float, b: float) -> dict[str, float | list[float] | str]:
+    total = a + b
+    return {"operation": "add", "operands": [a, b], "total": total}
+
+
+@mcp.tool(name="subtract")
+def subtract(a: float, b: float) -> dict[str, float | list[float] | str]:
+    total = a - b
+    return {"operation": "subtract", "operands": [a, b], "total": total}
+
+
+@mcp.tool(name="multiply")
+def multiply(a: float, b: float) -> dict[str, float | list[float] | str]:
+    total = a * b
+    return {"operation": "multiply", "operands": [a, b], "total": total}
+
+
+app = mcp.app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run helper
+    mcp.run(host="0.0.0.0", port=8001)
+

--- a/mcp_server/server_b/__init__.py
+++ b/mcp_server/server_b/__init__.py
@@ -1,0 +1,2 @@
+"""Weather MCP server package."""
+

--- a/mcp_server/server_b/server.py
+++ b/mcp_server/server_b/server.py
@@ -1,38 +1,44 @@
-"""
-FastMCP quickstart example.
+"""Weather MCP server built on the lightweight MCP utilities."""
+from __future__ import annotations
 
-cd to the `examples/snippets/clients` directory and run:
-    uv run server fastmcp_quickstart stdio
-"""
+from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp import MCPServer
 
-# Create an MCP server
-mcp = FastMCP("Demo")
+WEATHER_DATA: dict[str, dict[str, Any]] = {
+    "london": {"condition": "cloudy", "temperature_c": 16.0},
+    "new york": {"condition": "sunny", "temperature_c": 22.0},
+    "los angeles": {"condition": "clear", "temperature_c": 24.0},
+}
 
-
-# Add an addition tool
-@mcp.tool()
-def add(a: int, b: int) -> int:
-    """Add two numbers"""
-    return a + b
+server = MCPServer("Weather Toolkit")
 
 
-# Add a dynamic greeting resource
-@mcp.resource("greeting://{name}")
-def get_greeting(name: str) -> str:
-    """Get a personalized greeting"""
-    return f"Hello, {name}!"
+def _convert_temperature(value_c: float, unit: str) -> float:
+    if unit == "fahrenheit":
+        return round((value_c * 9 / 5) + 32, 1)
+    return value_c
 
 
-# Add a prompt
-@mcp.prompt()
-def greet_user(name: str, style: str = "friendly") -> str:
-    """Generate a greeting prompt"""
-    styles = {
-        "friendly": "Please write a warm, friendly greeting",
-        "formal": "Please write a formal, professional greeting",
-        "casual": "Please write a casual, relaxed greeting",
+@server.tool(name="current_weather")
+async def current_weather(location: str, unit: str = "celsius") -> dict[str, Any]:
+    normalized = location.strip().lower()
+    if normalized not in WEATHER_DATA:
+        raise ValueError(f"Weather data for '{location}' is not available")
+
+    entry = WEATHER_DATA[normalized]
+    temperature = _convert_temperature(entry["temperature_c"], unit)
+    return {
+        "location": location.title(),
+        "condition": entry["condition"],
+        "temperature": temperature,
+        "unit": unit,
     }
 
-    return f"{styles.get(style, styles['friendly'])} for someone named {name}."
+
+app = server.app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run helper
+    server.run(host="0.0.0.0", port=8002)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcp_ex"
+version = "0.1.0"
+description = "Example host and MCP servers"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.111",
+    "httpx>=0.27",
+    "pydantic>=2.5",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.5",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "UP"]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,30 @@
+import httpx
+import pytest
+
+from host.mcp_client.client_a import MathMCPClient
+from host.mcp_client.client_b import WeatherMCPClient
+from mcp_server.server_a import server as math_server
+from mcp_server.server_b import server as weather_server
+
+
+@pytest.mark.asyncio
+async def test_math_client_add() -> None:
+    transport = httpx.ASGITransport(app=math_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://math") as http_client:
+        client = MathMCPClient("http://math", http_client=http_client)
+        response = await client.add(7, 5)
+
+    assert response.result["total"] == 12
+    assert response.events[-1]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_weather_client_current_weather() -> None:
+    transport = httpx.ASGITransport(app=weather_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://weather") as http_client:
+        client = WeatherMCPClient("http://weather", http_client=http_client)
+        response = await client.current_weather("London")
+
+    assert response.result["condition"] == "cloudy"
+    assert response.result["temperature"] == pytest.approx(16.0)
+

--- a/tests/test_conversation_e2e.py
+++ b/tests/test_conversation_e2e.py
@@ -1,0 +1,88 @@
+import httpx
+import pytest
+
+from host.app.app import create_app
+from host.mcp_client.client_a import MathMCPClient
+from host.mcp_client.client_b import WeatherMCPClient
+from mcp_server.server_a import server as math_server
+from mcp_server.server_b import server as weather_server
+
+
+@pytest.mark.asyncio
+async def test_conversation_routes_to_math_tool() -> None:
+    math_transport = httpx.ASGITransport(app=math_server.app)
+    weather_transport = httpx.ASGITransport(app=weather_server.app)
+
+    async with httpx.AsyncClient(
+        transport=math_transport,
+        base_url="http://math",
+    ) as math_http:
+        async with httpx.AsyncClient(
+            transport=weather_transport,
+            base_url="http://weather",
+        ) as weather_http:
+            app = create_app(
+                math_client=MathMCPClient("http://math", http_client=math_http),
+                weather_client=WeatherMCPClient("http://weather", http_client=weather_http),
+            )
+            host_transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=host_transport,
+                base_url="http://host",
+            ) as host_client:
+                response = await host_client.post(
+                    "/conversation",
+                    json={"question": "What is 2 + 3?", "interaction_id": "math-1"},
+                )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tool"]["name"] == "math.add"
+    assert payload["reply"].startswith("The result of 2.0 + 3.0 is 5.0")
+
+
+@pytest.mark.asyncio
+async def test_conversation_routes_to_weather_tool_and_handles_fallback() -> None:
+    math_transport = httpx.ASGITransport(app=math_server.app)
+    weather_transport = httpx.ASGITransport(app=weather_server.app)
+
+    async with httpx.AsyncClient(
+        transport=math_transport,
+        base_url="http://math",
+    ) as math_http:
+        async with httpx.AsyncClient(
+            transport=weather_transport,
+            base_url="http://weather",
+        ) as weather_http:
+            app = create_app(
+                math_client=MathMCPClient("http://math", http_client=math_http),
+                weather_client=WeatherMCPClient("http://weather", http_client=weather_http),
+            )
+            host_transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=host_transport,
+                base_url="http://host",
+            ) as host_client:
+                weather_response = await host_client.post(
+                    "/conversation",
+                    json={
+                        "question": "Please share the weather in London in Fahrenheit.",
+                        "interaction_id": "weather-1",
+                    },
+                )
+                fallback_response = await host_client.post(
+                    "/conversation",
+                    json={"question": "Tell me a joke", "interaction_id": "none-1"},
+                )
+
+    assert weather_response.status_code == 200
+    weather_payload = weather_response.json()
+    assert weather_payload["tool"]["name"] == "weather.current_weather"
+    assert "London" in weather_payload["reply"]
+    assert "°F" in weather_payload["reply"]
+
+    assert fallback_response.status_code == 200
+    fallback_payload = fallback_response.json()
+    assert fallback_payload["tool"] is None
+    assert "math or the weather" in fallback_payload["reply"]
+

--- a/tests/test_math_server.py
+++ b/tests/test_math_server.py
@@ -1,0 +1,36 @@
+import json
+
+import httpx
+import pytest
+
+from mcp_server.server_a import server as math_server
+
+
+@pytest.mark.asyncio
+async def test_math_add_tool_streams_events() -> None:
+    transport = httpx.ASGITransport(app=math_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://math") as client:
+        async with client.stream("POST", "/tools/add", json={"a": 2, "b": 3}) as response:
+            assert response.status_code == 200
+            events = []
+            async for line in response.aiter_lines():
+                if line:
+                    events.append(json.loads(line))
+
+    assert events[0]["status"] == "started"
+    assert events[-1]["status"] == "completed"
+    assert events[-1]["result"]["total"] == 5
+
+
+@pytest.mark.asyncio
+async def test_math_multiply_tool() -> None:
+    transport = httpx.ASGITransport(app=math_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://math") as client:
+        async with client.stream("POST", "/tools/multiply", json={"a": 4, "b": 6}) as response:
+            lines = []
+            async for line in response.aiter_lines():
+                if line:
+                    lines.append(json.loads(line))
+
+    assert lines[-1]["result"]["total"] == 24
+

--- a/tests/test_weather_server.py
+++ b/tests/test_weather_server.py
@@ -1,0 +1,42 @@
+import json
+
+import httpx
+import pytest
+
+from mcp_server.server_b import server as weather_server
+
+
+@pytest.mark.asyncio
+async def test_weather_stream_contains_progress_event() -> None:
+    transport = httpx.ASGITransport(app=weather_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://weather") as client:
+        async with client.stream(
+            "POST", "/tools/current_weather", json={"location": "London", "unit": "celsius"}
+        ) as response:
+            events = []
+            async for line in response.aiter_lines():
+                if line:
+                    events.append(json.loads(line))
+
+    assert events[0]["status"] == "started"
+    assert any(event["status"] == "progress" for event in events)
+    final = events[-1]
+    assert final["status"] == "completed"
+    assert final["result"]["location"] == "London"
+
+
+@pytest.mark.asyncio
+async def test_weather_fahrenheit_conversion() -> None:
+    transport = httpx.ASGITransport(app=weather_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://weather") as client:
+        async with client.stream(
+            "POST", "/tools/current_weather", json={"location": "London", "unit": "fahrenheit"}
+        ) as response:
+            events = []
+            async for line in response.aiter_lines():
+                if line:
+                    events.append(json.loads(line))
+
+    assert round(events[-1]["result"]["temperature"], 1) == 60.8
+    assert events[-1]["result"]["unit"] == "fahrenheit"
+


### PR DESCRIPTION
## Summary
- implement a FastAPI conversation host that selects math or weather MCP tools and returns formatted replies
- build streaming math and weather MCP servers alongside lightweight fastmcp/mcp shims and dedicated HTTP clients
- add an automated test suite plus documentation covering features, history, setup, and future enhancements

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf1262ba8083339919fb91dc4ddb81